### PR TITLE
Add an experimental channel callback

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -43,6 +43,9 @@ type PasswordHandler func(user, password string) bool
 // PermissionsCallback is a hook for setting up user permissions.
 type PermissionsCallback func(user string, permissions *Permissions) error
 
+// ChannelCallback is a hook for allowing new channels.
+type ChannelCallback func(user string, permissions *Permissions) bool
+
 // PtyCallback is a hook for allowing PTY sessions.
 type PtyCallback func(user string, permissions *Permissions) bool
 


### PR DESCRIPTION
This is a pretty small change which lets users deny ssh channels. We plan on using this to deny everything after the first one, but there may be other uses as well. It's modeled after the PtyCallback.