### PR TITLE
contexts

### DIFF
--- a/_example/ssh-publickey/public_key.go
+++ b/_example/ssh-publickey/public_key.go
@@ -16,7 +16,7 @@ func main() {
 		s.Write(authorizedKey)
 	})
 
-	publicKeyOption := ssh.PublicKeyAuth(func(user string, key ssh.PublicKey) bool {
+	publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
 		return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
 	})
 

--- a/context.go
+++ b/context.go
@@ -14,26 +14,72 @@ type contextKey struct {
 }
 
 var (
-	ContextKeyUser          = &contextKey{"user"}
-	ContextKeySessionID     = &contextKey{"session-id"}
-	ContextKeyPermissions   = &contextKey{"permissions"}
+	// ContextKeyUser is a context key for use with Contexts in this package.
+	// The associated value will be of type string.
+	ContextKeyUser = &contextKey{"user"}
+
+	// ContextKeySessionID is a context key for use with Contexts in this package.
+	// The associated value will be of type []byte.
+	ContextKeySessionID = &contextKey{"session-id"}
+
+	// ContextKeyPermissions is a context key for use with Contexts in this package.
+	// The associated value will be of type *Permissions.
+	ContextKeyPermissions = &contextKey{"permissions"}
+
+	// ContextKeyClientVersion is a context key for use with Contexts in this package.
+	// The associated value will be of type []byte.
 	ContextKeyClientVersion = &contextKey{"client-version"}
+
+	// ContextKeyServerVersion is a context key for use with Contexts in this package.
+	// The associated value will be of type []byte.
 	ContextKeyServerVersion = &contextKey{"server-version"}
-	ContextKeyLocalAddr     = &contextKey{"local-addr"}
-	ContextKeyRemoteAddr    = &contextKey{"remote-addr"}
-	ContextKeyServer        = &contextKey{"ssh-server"}
-	ContextKeyPublicKey     = &contextKey{"public-key"}
+
+	// ContextKeyLocalAddr is a context key for use with Contexts in this package.
+	// The associated value will be of type net.Addr.
+	ContextKeyLocalAddr = &contextKey{"local-addr"}
+
+	// ContextKeyRemoteAddr is a context key for use with Contexts in this package.
+	// The associated value will be of type net.Addr.
+	ContextKeyRemoteAddr = &contextKey{"remote-addr"}
+
+	// ContextKeyServer is a context key for use with Contexts in this package.
+	// The associated value will be of type *Server.
+	ContextKeyServer = &contextKey{"ssh-server"}
+
+	// ContextKeyPublicKey is a context key for use with Contexts in this package.
+	// The associated value will be of type PublicKey.
+	ContextKeyPublicKey = &contextKey{"public-key"}
 )
 
+// Context is a package specific context interface. It exposes connection
+// metadata and allows new values to be easily written to it. It's used in
+// authentication handlers and callbacks, and its underlying context.Context is
+// exposed on Session in the session Handler.
 type Context interface {
 	context.Context
+
+	// User returns the username used when establishing the SSH connection.
 	User() string
+
+	// SessionID returns the session hash.
 	SessionID() string
+
+	// ClientVersion returns the version reported by the client.
 	ClientVersion() string
+
+	// ServerVersion returns the version reported by the server.
 	ServerVersion() string
+
+	// RemoteAddr returns the remote address for this connection.
 	RemoteAddr() net.Addr
+
+	// LocalAddr returns the local address for this connection.
 	LocalAddr() net.Addr
+
+	// Permissions returns the Permissions object used for this connection.
 	Permissions() *Permissions
+
+	// SetValue allows you to easily write new values into the underlying context.
 	SetValue(key, value interface{})
 }
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,102 @@
+package ssh
+
+import (
+	"context"
+	"net"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// contextKey is a value for use with context.WithValue. It's used as
+// a pointer so it fits in an interface{} without allocation.
+type contextKey struct {
+	name string
+}
+
+var (
+	ContextKeyUser          = &contextKey{"user"}
+	ContextKeySessionID     = &contextKey{"session-id"}
+	ContextKeyPermissions   = &contextKey{"permissions"}
+	ContextKeyClientVersion = &contextKey{"client-version"}
+	ContextKeyServerVersion = &contextKey{"server-version"}
+	ContextKeyLocalAddr     = &contextKey{"local-addr"}
+	ContextKeyRemoteAddr    = &contextKey{"remote-addr"}
+	ContextKeyServer        = &contextKey{"ssh-server"}
+	ContextKeyPublicKey     = &contextKey{"public-key"}
+)
+
+type Context interface {
+	context.Context
+	User() string
+	SessionID() string
+	ClientVersion() string
+	ServerVersion() string
+	RemoteAddr() net.Addr
+	LocalAddr() net.Addr
+	Permissions() *Permissions
+	SetValue(key, value interface{})
+}
+
+type sshContext struct {
+	context.Context
+}
+
+func newContext(srv *Server) *sshContext {
+	ctx := &sshContext{context.Background()}
+	ctx.SetValue(ContextKeyServer, srv)
+	perms := &Permissions{&gossh.Permissions{}}
+	ctx.SetValue(ContextKeyPermissions, perms)
+	return ctx
+}
+
+// this is separate from newContext because we will get ConnMetadata
+// at different points so it needs to be applied separately
+func (ctx *sshContext) applyConnMetadata(conn gossh.ConnMetadata) {
+	if ctx.Value(ContextKeySessionID) != nil {
+		return
+	}
+	// for most of these, instead of converting to strings now, storing the byte
+	// slices means allocations only happen when accessing, not when contexts
+	// are being copied around
+	ctx.SetValue(ContextKeySessionID, conn.SessionID())
+	ctx.SetValue(ContextKeyClientVersion, conn.ClientVersion())
+	ctx.SetValue(ContextKeyServerVersion, conn.ServerVersion())
+	ctx.SetValue(ContextKeyUser, conn.User())
+	ctx.SetValue(ContextKeyLocalAddr, conn.LocalAddr())
+	ctx.SetValue(ContextKeyRemoteAddr, conn.RemoteAddr())
+}
+
+func (ctx *sshContext) SetValue(key, value interface{}) {
+	ctx.Context = context.WithValue(ctx.Context, key, value)
+}
+
+func (ctx *sshContext) User() string {
+	return ctx.Value(ContextKeyUser).(string)
+}
+
+func (ctx *sshContext) SessionID() string {
+	id, _ := ctx.Value(ContextKeySessionID).([]byte)
+	return string(id)
+}
+
+func (ctx *sshContext) ClientVersion() string {
+	version, _ := ctx.Value(ContextKeyClientVersion).([]byte)
+	return string(version)
+}
+
+func (ctx *sshContext) ServerVersion() string {
+	version, _ := ctx.Value(ContextKeyServerVersion).([]byte)
+	return string(version)
+}
+
+func (ctx *sshContext) RemoteAddr() net.Addr {
+	return ctx.Value(ContextKeyRemoteAddr).(net.Addr)
+}
+
+func (ctx *sshContext) LocalAddr() net.Addr {
+	return ctx.Value(ContextKeyLocalAddr).(net.Addr)
+}
+
+func (ctx *sshContext) Permissions() *Permissions {
+	return ctx.Value(ContextKeyPermissions).(*Permissions)
+}

--- a/context.go
+++ b/context.go
@@ -19,7 +19,7 @@ var (
 	ContextKeyUser = &contextKey{"user"}
 
 	// ContextKeySessionID is a context key for use with Contexts in this package.
-	// The associated value will be of type []byte.
+	// The associated value will be of type string.
 	ContextKeySessionID = &contextKey{"session-id"}
 
 	// ContextKeyPermissions is a context key for use with Contexts in this package.
@@ -27,11 +27,11 @@ var (
 	ContextKeyPermissions = &contextKey{"permissions"}
 
 	// ContextKeyClientVersion is a context key for use with Contexts in this package.
-	// The associated value will be of type []byte.
+	// The associated value will be of type string.
 	ContextKeyClientVersion = &contextKey{"client-version"}
 
 	// ContextKeyServerVersion is a context key for use with Contexts in this package.
-	// The associated value will be of type []byte.
+	// The associated value will be of type string.
 	ContextKeyServerVersion = &contextKey{"server-version"}
 
 	// ContextKeyLocalAddr is a context key for use with Contexts in this package.
@@ -101,12 +101,9 @@ func (ctx *sshContext) applyConnMetadata(conn gossh.ConnMetadata) {
 	if ctx.Value(ContextKeySessionID) != nil {
 		return
 	}
-	// for most of these, instead of converting to strings now, storing the byte
-	// slices means allocations only happen when accessing, not when contexts
-	// are being copied around
-	ctx.SetValue(ContextKeySessionID, conn.SessionID())
-	ctx.SetValue(ContextKeyClientVersion, conn.ClientVersion())
-	ctx.SetValue(ContextKeyServerVersion, conn.ServerVersion())
+	ctx.SetValue(ContextKeySessionID, string(conn.SessionID()))
+	ctx.SetValue(ContextKeyClientVersion, string(conn.ClientVersion()))
+	ctx.SetValue(ContextKeyServerVersion, string(conn.ServerVersion()))
 	ctx.SetValue(ContextKeyUser, conn.User())
 	ctx.SetValue(ContextKeyLocalAddr, conn.LocalAddr())
 	ctx.SetValue(ContextKeyRemoteAddr, conn.RemoteAddr())
@@ -121,18 +118,15 @@ func (ctx *sshContext) User() string {
 }
 
 func (ctx *sshContext) SessionID() string {
-	id, _ := ctx.Value(ContextKeySessionID).([]byte)
-	return string(id)
+	return ctx.Value(ContextKeySessionID).(string)
 }
 
 func (ctx *sshContext) ClientVersion() string {
-	version, _ := ctx.Value(ContextKeyClientVersion).([]byte)
-	return string(version)
+	return ctx.Value(ContextKeyClientVersion).(string)
 }
 
 func (ctx *sshContext) ServerVersion() string {
-	version, _ := ctx.Value(ContextKeyServerVersion).([]byte)
-	return string(version)
+	return ctx.Value(ContextKeyServerVersion).(string)
 }
 
 func (ctx *sshContext) RemoteAddr() net.Addr {

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,47 @@
+package ssh
+
+import "testing"
+
+func TestSetPermissions(t *testing.T) {
+	t.Parallel()
+	permsExt := map[string]string{
+		"foo": "bar",
+	}
+	session, cleanup := newTestSessionWithOptions(t, &Server{
+		Handler: func(s Session) {
+			if _, ok := s.Permissions().Extensions["foo"]; !ok {
+				t.Fatalf("got %#v; want %#v", s.Permissions().Extensions, permsExt)
+			}
+		},
+	}, nil, PasswordAuth(func(ctx Context, password string) bool {
+		ctx.Permissions().Extensions = permsExt
+		return true
+	}))
+	defer cleanup()
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSetValue(t *testing.T) {
+	t.Parallel()
+	value := map[string]string{
+		"foo": "bar",
+	}
+	key := "testValue"
+	session, cleanup := newTestSessionWithOptions(t, &Server{
+		Handler: func(s Session) {
+			v := s.Context().Value(key).(map[string]string)
+			if v["foo"] != value["foo"] {
+				t.Fatalf("got %#v; want %#v", v, value)
+			}
+		},
+	}, nil, PasswordAuth(func(ctx Context, password string) bool {
+		ctx.SetValue(key, value)
+		return true
+	}))
+	defer cleanup()
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func ExampleListenAndServe() {
 
 func ExamplePasswordAuth() {
 	ssh.ListenAndServe(":2222", nil,
-		ssh.PasswordAuth(func(user, pass string) bool {
+		ssh.PasswordAuth(func(ctx ssh.Context, pass string) bool {
 			return pass == "secret"
 		}),
 	)
@@ -27,7 +27,7 @@ func ExampleNoPty() {
 
 func ExamplePublicKeyAuth() {
 	ssh.ListenAndServe(":2222", nil,
-		ssh.PublicKeyAuth(func(user string, key ssh.PublicKey) bool {
+		ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
 			data, _ := ioutil.ReadFile("/path/to/allowed/key.pub")
 			allowed, _, _, _, _ := ssh.ParseAuthorizedKey(data)
 			return ssh.KeysEqual(key, allowed)

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ func HostKeyPEM(bytes []byte) Option {
 // denying PTY requests.
 func NoPty() Option {
 	return func(srv *Server) error {
-		srv.PtyCallback = func(user string, permissions *Permissions) bool {
+		srv.PtyCallback = func(ctx Context, pty Pty) bool {
 			return false
 		}
 		return nil

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,66 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func newTestSessionWithOptions(t *testing.T, srv *Server, cfg *gossh.ClientConfig, options ...Option) (*gossh.Session, func()) {
+	for _, option := range options {
+		if err := srv.SetOption(option); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return newTestSession(t, srv, cfg)
+}
+
+func TestPasswordAuth(t *testing.T) {
+	t.Parallel()
+	testUser := "testuser"
+	testPass := "testpass"
+	session, cleanup := newTestSessionWithOptions(t, &Server{
+		Handler: func(s Session) {
+			// noop
+		},
+	}, &gossh.ClientConfig{
+		User: testUser,
+		Auth: []gossh.AuthMethod{
+			gossh.Password(testPass),
+		},
+	}, PasswordAuth(func(ctx Context, password string) bool {
+		if ctx.User() != testUser {
+			t.Fatalf("user = %#v; want %#v", ctx.User(), testUser)
+		}
+		if password != testPass {
+			t.Fatalf("user = %#v; want %#v", password, testPass)
+		}
+		return true
+	}))
+	defer cleanup()
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPasswordAuthBadPass(t *testing.T) {
+	t.Parallel()
+	l := newLocalListener()
+	srv := &Server{Handler: func(s Session) {}}
+	srv.SetOption(PasswordAuth(func(ctx Context, password string) bool {
+		return false
+	}))
+	go srv.serveOnce(l)
+	_, err := gossh.Dial("tcp", l.Addr().String(), &gossh.ClientConfig{
+		User: "testuser",
+		Auth: []gossh.AuthMethod{
+			gossh.Password("testpass"),
+		},
+	})
+	if err != nil {
+		if !strings.Contains(err.Error(), "unable to authenticate") {
+			t.Fatal(err)
+		}
+	}
+}

--- a/session.go
+++ b/session.go
@@ -44,8 +44,13 @@ type Session interface {
 	// used it will return nil.
 	PublicKey() PublicKey
 
+	// Context returns the connection's context. The returned context is always
+	// non-nil and holds the same data as the Context passed into auth
+	// handlers and callbacks.
 	Context() context.Context
 
+	// Permissions returns a copy of the Permissions object that was available for
+	// setup in the auth handlers via the Context.
 	Permissions() Permissions
 
 	// Pty returns PTY information, a channel of window size changes, and a boolean

--- a/session_test.go
+++ b/session_test.go
@@ -11,15 +11,14 @@ import (
 )
 
 func (srv *Server) serveOnce(l net.Listener) error {
-	config, err := srv.makeConfig()
-	if err != nil {
+	if err := srv.ensureHostSigner(); err != nil {
 		return err
 	}
 	conn, e := l.Accept()
 	if e != nil {
 		return e
 	}
-	srv.handleConn(conn, config)
+	srv.handleConn(conn)
 	return nil
 }
 
@@ -63,6 +62,7 @@ func newTestSession(t *testing.T, srv *Server, cfg *gossh.ClientConfig) (*gossh.
 }
 
 func TestStdout(t *testing.T) {
+	t.Parallel()
 	testBytes := []byte("Hello world\n")
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
@@ -81,6 +81,7 @@ func TestStdout(t *testing.T) {
 }
 
 func TestStderr(t *testing.T) {
+	t.Parallel()
 	testBytes := []byte("Hello world\n")
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
@@ -99,6 +100,7 @@ func TestStderr(t *testing.T) {
 }
 
 func TestStdin(t *testing.T) {
+	t.Parallel()
 	testBytes := []byte("Hello world\n")
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
@@ -118,6 +120,7 @@ func TestStdin(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
+	t.Parallel()
 	testUser := []byte("progrium")
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
@@ -138,6 +141,7 @@ func TestUser(t *testing.T) {
 }
 
 func TestDefaultExitStatusZero(t *testing.T) {
+	t.Parallel()
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
 			// noop
@@ -151,6 +155,7 @@ func TestDefaultExitStatusZero(t *testing.T) {
 }
 
 func TestExplicitExitStatusZero(t *testing.T) {
+	t.Parallel()
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
 			s.Exit(0)
@@ -164,6 +169,7 @@ func TestExplicitExitStatusZero(t *testing.T) {
 }
 
 func TestExitStatusNonZero(t *testing.T) {
+	t.Parallel()
 	session, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {
 			s.Exit(1)
@@ -181,6 +187,7 @@ func TestExitStatusNonZero(t *testing.T) {
 }
 
 func TestPty(t *testing.T) {
+	t.Parallel()
 	term := "xterm"
 	winWidth := 40
 	winHeight := 80
@@ -214,6 +221,7 @@ func TestPty(t *testing.T) {
 }
 
 func TestPtyResize(t *testing.T) {
+	t.Parallel()
 	winch0 := Window{40, 80}
 	winch1 := Window{80, 160}
 	winch2 := Window{20, 40}

--- a/ssh.go
+++ b/ssh.go
@@ -34,16 +34,13 @@ type Option func(*Server) error
 type Handler func(Session)
 
 // PublicKeyHandler is a callback for performing public key authentication.
-type PublicKeyHandler func(user string, key PublicKey) bool
+type PublicKeyHandler func(ctx Context, key PublicKey) bool
 
 // PasswordHandler is a callback for performing password authentication.
-type PasswordHandler func(user, password string) bool
-
-// PermissionsCallback is a hook for setting up user permissions.
-type PermissionsCallback func(user string, permissions *Permissions) error
+type PasswordHandler func(ctx Context, password string) bool
 
 // PtyCallback is a hook for allowing PTY sessions.
-type PtyCallback func(user string, permissions *Permissions) bool
+type PtyCallback func(ctx Context, pty Pty) bool
 
 // Window represents the size of a PTY window.
 type Window struct {

--- a/wrap.go
+++ b/wrap.go
@@ -10,8 +10,7 @@ type PublicKey interface {
 // The Permissions type holds fine-grained permissions that are specific to a
 // user or a specific authentication method for a user. Permissions, except for
 // "source-address", must be enforced in the server application layer, after
-// successful authentication. The Permissions are passed on in ServerConn so a
-// server implementation can honor them.
+// successful authentication.
 type Permissions struct {
 	*gossh.Permissions
 }


### PR DESCRIPTION
Implements a special ssh.Context that captures gossh.ConnMetadata and context.Context made for better callbacks and session setup, then exposed as regular context.Context on ssh.Session

Standardizes callbacks more while giving them access to more information and letting them contribute to state that would be made available to Session handler. Removes the need for PermissionsCallback as Permissions are exposed on ssh.Context. Generally simplifies code overall, while increasing capabilities, and remaining fairly Go idiomatic.

Todo: godocs, more tests