### PR TITLE
agent forwarding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,28 @@ building SSH servers. The goal of the API was to make it as simple as using
 
 ```
  package main
- 
+
  import (
      "github.com/gliderlabs/ssh"
      "io"
      "log"
  )
- 
+
  func main() {
      ssh.Handle(func(s ssh.Session) {
          io.WriteString(s, "Hello world\n")
      })  
- 
+
      log.Fatal(ssh.ListenAndServe(":2222", nil))
  }
 
 ```
 
-This package was built after working on nearly a dozen projects using SSH and
-collaborating with [@shazow](https://twitter.com/shazow) (known for [ssh-chat](https://github.com/shazow/ssh-chat)).
+This package was built after working on nearly a dozen projects at Glider Labs using SSH and collaborating with [@shazow](https://twitter.com/shazow) (known for [ssh-chat](https://github.com/shazow/ssh-chat)).
+
+## Examples
+
+A bunch of great examples are in the `_example` directory.
 
 ## Usage
 

--- a/_example/ssh-forwardagent/forwardagent.go
+++ b/_example/ssh-forwardagent/forwardagent.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/gliderlabs/ssh"
+)
+
+func main() {
+	ssh.Handle(func(s ssh.Session) {
+		cmd := exec.Command("ssh-add", "-l")
+		if ssh.AgentRequested(s) {
+			l, err := ssh.NewAgentListener()
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer l.Close()
+			go ssh.ForwardAgentConnections(l, s)
+			cmd.Env = append(s.Environ(), fmt.Sprintf("%s=%s", "SSH_AUTH_SOCK", l.Addr().String()))
+		} else {
+			cmd.Env = s.Environ()
+		}
+		cmd.Stdout = s
+		cmd.Stderr = s.Stderr()
+		if err := cmd.Run(); err != nil {
+			log.Println(err)
+			return
+		}
+	})
+
+	log.Println("starting ssh server on port 2222...")
+	log.Fatal(ssh.ListenAndServe(":2222", nil))
+}

--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,70 @@
+package ssh
+
+import (
+	"io"
+	"io/ioutil"
+	"net"
+	"path"
+	"sync"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const (
+	agentRequestType = "auth-agent-req@openssh.com"
+	agentChannelType = "auth-agent@openssh.com"
+)
+
+var contextKeyAgentRequest = &contextKey{"auth-agent-req"}
+
+func setAgentRequested(sess *session) {
+	sess.ctx.SetValue(contextKeyAgentRequest, true)
+}
+
+func AgentRequested(sess Session) bool {
+	return sess.Context().Value(contextKeyAgentRequest) == true
+}
+
+func NewAgentListener() (net.Listener, error) {
+	dir, err := ioutil.TempDir("", "auth-agent")
+	if err != nil {
+		return nil, err
+	}
+	l, err := net.Listen("unix", path.Join(dir, "listener.sock"))
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func ForwardAgentConnections(l net.Listener, s Session) {
+	sshConn := s.Context().Value(ContextKeyConn).(gossh.Conn)
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer conn.Close()
+			channel, reqs, err := sshConn.OpenChannel(agentChannelType, nil)
+			if err != nil {
+				return
+			}
+			defer channel.Close()
+			go gossh.DiscardRequests(reqs)
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				io.Copy(conn, channel)
+				conn.(*net.UnixConn).CloseWrite()
+				wg.Done()
+			}()
+			go func() {
+				io.Copy(channel, conn)
+				channel.CloseWrite()
+				wg.Done()
+			}()
+			wg.Wait()
+		}()
+	}
+}

--- a/agent.go
+++ b/agent.go
@@ -44,7 +44,7 @@ func ForwardAgentConnections(l net.Listener, s Session) {
 		if err != nil {
 			return
 		}
-		go func() {
+		go func(conn net.Conn) {
 			defer conn.Close()
 			channel, reqs, err := sshConn.OpenChannel(agentChannelType, nil)
 			if err != nil {
@@ -65,6 +65,6 @@ func ForwardAgentConnections(l net.Listener, s Session) {
 				wg.Done()
 			}()
 			wg.Wait()
-		}()
+		}(conn)
 	}
 }

--- a/context.go
+++ b/context.go
@@ -46,6 +46,10 @@ var (
 	// The associated value will be of type *Server.
 	ContextKeyServer = &contextKey{"ssh-server"}
 
+	// ContextKeyConn is a context key for use with Contexts in this package.
+	// The associated value will be of type gossh.Conn.
+	ContextKeyConn = &contextKey{"ssh-conn"}
+
 	// ContextKeyPublicKey is a context key for use with Contexts in this package.
 	// The associated value will be of type PublicKey.
 	ContextKeyPublicKey = &contextKey{"public-key"}

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"context"
 	"net"
+	"encoding/hex"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -105,7 +106,7 @@ func (ctx *sshContext) applyConnMetadata(conn gossh.ConnMetadata) {
 	if ctx.Value(ContextKeySessionID) != nil {
 		return
 	}
-	ctx.SetValue(ContextKeySessionID, string(conn.SessionID()))
+	ctx.SetValue(ContextKeySessionID, hex.EncodeToString(conn.SessionID()))
 	ctx.SetValue(ContextKeyClientVersion, string(conn.ClientVersion()))
 	ctx.SetValue(ContextKeyServerVersion, string(conn.ServerVersion()))
 	ctx.SetValue(ContextKeyUser, conn.User())

--- a/options_test.go
+++ b/options_test.go
@@ -29,6 +29,7 @@ func TestPasswordAuth(t *testing.T) {
 		Auth: []gossh.AuthMethod{
 			gossh.Password(testPass),
 		},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	}, PasswordAuth(func(ctx Context, password string) bool {
 		if ctx.User() != testUser {
 			t.Fatalf("user = %#v; want %#v", ctx.User(), testUser)
@@ -57,6 +58,7 @@ func TestPasswordAuthBadPass(t *testing.T) {
 		Auth: []gossh.AuthMethod{
 			gossh.Password("testpass"),
 		},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	})
 	if err != nil {
 		if !strings.Contains(err.Error(), "unable to authenticate") {

--- a/session_test.go
+++ b/session_test.go
@@ -41,6 +41,9 @@ func newClientSession(t *testing.T, addr string, config *gossh.ClientConfig) (*g
 			},
 		}
 	}
+	if config.HostKeyCallback == nil {
+		config.HostKeyCallback = gossh.InsecureIgnoreHostKey()
+	}
 	client, err := gossh.Dial("tcp", addr, config)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Originally we thought [crypto/ssh/agent](https://godoc.org/golang.org/x/crypto/ssh/agent) would give us this functionality, but that package is just the agent server and ssh client part. Basically the first leg. The second leg (between a forwarding unix socket made by the ssh server and the ssh client there) is not terribly well documented but is actually pretty straightforward.

Also included is an example. Documentation to come after review. Also, thoughts on testing this?

I also started the infrastructure for making channel type handlers easier to add. For some reason I was thinking I had to handle the agent forwarding channel, but it's actually done on the client side. So it was unnecessary, but we'll have to add new channel types eventually and this is a step in that direction.