### PR TITLE
check for nil interface before returning public key

### DIFF
--- a/session.go
+++ b/session.go
@@ -107,7 +107,11 @@ func (sess *session) Write(p []byte) (n int, err error) {
 }
 
 func (sess *session) PublicKey() PublicKey {
-	return sess.ctx.Value(ContextKeyPublicKey).(PublicKey)
+	sessionkey := sess.ctx.Value(ContextKeyPublicKey)
+	if sessionkey == nil {
+		return nil
+	}
+	return sessionkey.(PublicKey)
 }
 
 func (sess *session) Permissions() Permissions {


### PR DESCRIPTION
If public key is not used as authentication mode, interface is nil
This patch makes sure interface is not nil before trying the type assertion.

Here is the panic:

```
panic: interface conversion: interface is nil, not ssh.PublicKey

goroutine 9 [running]:
github.com/gliderlabs/ssh.(*session).PublicKey(0xc420073480, 0xc42000c020, 0xc420103d88)
        /home/aert/go/src/github.com/gliderlabs/ssh/session.go:110 +0x77
main.newuserhandler(0x8082c0, 0xc420073480)
        /home/aert/go/src/sshd/sshd-useradd/main.go:65 +0x2df
github.com/gliderlabs/ssh.(*session).handleRequests.func1(0xc420073480)
        /home/aert/go/src/github.com/gliderlabs/ssh/session.go:176 +0x3b
created by github.com/gliderlabs/ssh.(*session).handleRequests
        /home/aert/go/src/github.com/gliderlabs/ssh/session.go:178 +0x2a1
```