### PR TITLE
update config for CircleCI 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
-test:
-  override:
-    - go test -v -race
+version: 2.0
+jobs:
+  build:
+    docker:
+    - image: golang:1.8
+    working_directory: /go/src/github.com/gliderlabs/ssh
+    steps:
+    - checkout
+    - run: go get
+    - run: go test -v -race


### PR DESCRIPTION
Update repo to use 2.0.  Build time is [7 seconds](https://circleci.com/gh/notnoopci/ssh/4) compared to [1.5 minutes](https://circleci.com/gh/gliderlabs/ssh/21).

A bit self-serving I must admit - but noticed that other gliderlabs public repos already use 2.0 - so felt more OK doing it :).