### PR TITLE
Move channelHandlers to avoid data race

### DIFF
--- a/server.go
+++ b/server.go
@@ -56,10 +56,6 @@ func (srv *Server) ensureHostSigner() error {
 }
 
 func (srv *Server) config(ctx *sshContext) *gossh.ServerConfig {
-	srv.channelHandlers = map[string]channelHandler{
-		"session":      sessionHandler,
-		"direct-tcpip": directTcpipHandler,
-	}
 	config := &gossh.ServerConfig{}
 	for _, signer := range srv.HostSigners {
 		config.AddHostKey(signer)
@@ -163,6 +159,12 @@ func (srv *Server) Serve(l net.Listener) error {
 	}
 	if srv.Handler == nil {
 		srv.Handler = DefaultHandler
+	}
+	if srv.channelHandlers == nil {
+		srv.channelHandlers = map[string]channelHandler{
+			"session":      sessionHandler,
+			"direct-tcpip": directTcpipHandler,
+		}
 	}
 	var tempDelay time.Duration
 

--- a/session_test.go
+++ b/session_test.go
@@ -18,6 +18,10 @@ func (srv *Server) serveOnce(l net.Listener) error {
 	if e != nil {
 		return e
 	}
+	srv.channelHandlers = map[string]channelHandler{
+		"session":      sessionHandler,
+		"direct-tcpip": directTcpipHandler,
+	}
 	srv.handleConn(conn)
 	return nil
 }


### PR DESCRIPTION
There was a data race on the channelHandlers variable when there were multiple simultaneous connections.

Moving this function as in this PR is one option to resolve, and prepares for future changes if you wanted channelHandlers to be overridable. 

Another option would just be to add srv.mu.Lock() and Unlock() around the current location of the code in the config function and the read in handleConn, but the changes in this PR seemed cleaner to me.