### PR TITLE
Switch to using gossh.ParsePrivateKey when reading private keys

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package ssh
 
-import "io/ioutil"
+import (
+	"io/ioutil"
+
+	gossh "golang.org/x/crypto/ssh"
+)
 
 // PasswordAuth returns a functional option that sets PasswordHandler on the server.
 func PasswordAuth(fn PasswordHandler) Option {
@@ -26,13 +30,14 @@ func HostKeyFile(filepath string) Option {
 		if err != nil {
 			return err
 		}
-		for _, block := range decodePemBlocks(pemBytes) {
-			signer, err := signerFromBlock(block)
-			if err != nil {
-				return err
-			}
-			srv.AddHostKey(signer)
+
+		signer, err := gossh.ParsePrivateKey(pemBytes)
+		if err != nil {
+			return err
 		}
+
+		srv.AddHostKey(signer)
+
 		return nil
 	}
 }
@@ -41,13 +46,13 @@ func HostKeyFile(filepath string) Option {
 // from a PEM file as bytes.
 func HostKeyPEM(bytes []byte) Option {
 	return func(srv *Server) error {
-		for _, block := range decodePemBlocks(bytes) {
-			signer, err := signerFromBlock(block)
-			if err != nil {
-				return err
-			}
-			srv.AddHostKey(signer)
+		signer, err := gossh.ParsePrivateKey(bytes)
+		if err != nil {
+			return err
 		}
+
+		srv.AddHostKey(signer)
+
 		return nil
 	}
 }

--- a/util.go
+++ b/util.go
@@ -3,48 +3,10 @@ package ssh
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/binary"
-	"encoding/pem"
-	"fmt"
 
 	"golang.org/x/crypto/ssh"
 )
-
-func signerFromBlock(block *pem.Block) (ssh.Signer, error) {
-	var key interface{}
-	var err error
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "EC PRIVATE KEY":
-		key, err = x509.ParseECPrivateKey(block.Bytes)
-	case "DSA PRIVATE KEY":
-		key, err = ssh.ParseDSAPrivateKey(block.Bytes)
-	default:
-		return nil, fmt.Errorf("unsupported key type %q", block.Type)
-	}
-	if err != nil {
-		return nil, err
-	}
-	signer, err := ssh.NewSignerFromKey(key)
-	if err != nil {
-		return nil, err
-	}
-	return signer, nil
-}
-
-func decodePemBlocks(pemData []byte) []*pem.Block {
-	var blocks []*pem.Block
-	var block *pem.Block
-	for {
-		block, pemData = pem.Decode(pemData)
-		if block == nil {
-			return blocks
-		}
-		blocks = append(blocks, block)
-	}
-}
 
 func generateSigner() (ssh.Signer, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 768)


### PR DESCRIPTION
As mentioned in #56 this means we would only be able to parse one private key per file, but I don't think it's common practice to store multiple private ssh keys in one file.