### PR TITLE
Update circleci config to test multiple go versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,26 @@
-version: 2.0
+version: 2
 jobs:
-  build:
+  build-go-latest:
     docker:
-    - image: golang:1.10
+    - image: golang:latest
     working_directory: /go/src/github.com/gliderlabs/ssh
     steps:
     - checkout
     - run: go get
     - run: go test -v -race
+
+  build-go-1.7:
+    docker:
+    - image: golang:1.7
+    working_directory: /go/src/github.com/gliderlabs/ssh
+    steps:
+    - checkout
+    - run: go get
+    - run: go test -v -race
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-go-latest
+      - build-go-1.7


### PR DESCRIPTION
It's probably worth testing the oldest version we support (which would be 1.7 due to the addition of `Context`) and the latest version. We could support 1.7 through 1.10 and manually add new versions... or any number of options, but this seemed to make the most sense to me.

This is meant more as an experiment - if you'd rather not switch to this, that's fine too.

The names of the builds are still open for comments, if anyone has preferences.

If we do decide to go with this, it may be worth making these required builds.