### PR TITLE
Update CircleCI config to test 1.9 and the latest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ jobs:
     - run: go get
     - run: go test -v -race
 
-  build-go-1.7:
+  build-go-1.9:
     docker:
-    - image: golang:1.7
+    - image: golang:1.9
     working_directory: /go/src/github.com/gliderlabs/ssh
     steps:
     - checkout
@@ -23,4 +23,4 @@ workflows:
   build:
     jobs:
       - build-go-latest
-      - build-go-1.7
+      - build-go-1.9


### PR DESCRIPTION
The x/crypto/ssh library dropped support go < 1.9 as that's the first
version to have the math/bits library.

https://github.com/golang/crypto/commit/83c378c48d6ee2ca9c20551b599aa74cb7765785