### PR TITLE
Add SessionPolicyCallback

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"net"
+	"sync"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -59,9 +60,11 @@ var (
 // Context is a package specific context interface. It exposes connection
 // metadata and allows new values to be easily written to it. It's used in
 // authentication handlers and callbacks, and its underlying context.Context is
-// exposed on Session in the session Handler.
+// exposed on Session in the session Handler. This also embeds a sync.Locker so
+// values can safely be set between different sessions.
 type Context interface {
 	context.Context
+	sync.Locker
 
 	// User returns the username used when establishing the SSH connection.
 	User() string
@@ -90,11 +93,12 @@ type Context interface {
 
 type sshContext struct {
 	context.Context
+	sync.Mutex
 }
 
 func newContext(srv *Server) (*sshContext, context.CancelFunc) {
 	innerCtx, cancel := context.WithCancel(context.Background())
-	ctx := &sshContext{innerCtx}
+	ctx := &sshContext{innerCtx, sync.Mutex{}}
 	ctx.SetValue(ContextKeyServer, srv)
 	perms := &Permissions{&gossh.Permissions{}}
 	ctx.SetValue(ContextKeyPermissions, perms)

--- a/context.go
+++ b/context.go
@@ -93,12 +93,12 @@ type Context interface {
 
 type sshContext struct {
 	context.Context
-	sync.Mutex
+	*sync.Mutex
 }
 
 func newContext(srv *Server) (*sshContext, context.CancelFunc) {
 	innerCtx, cancel := context.WithCancel(context.Background())
-	ctx := &sshContext{innerCtx, sync.Mutex{}}
+	ctx := &sshContext{innerCtx, &sync.Mutex{}}
 	ctx.SetValue(ContextKeyServer, srv)
 	perms := &Permissions{&gossh.Permissions{}}
 	ctx.SetValue(ContextKeyPermissions, perms)

--- a/context.go
+++ b/context.go
@@ -60,8 +60,8 @@ var (
 // Context is a package specific context interface. It exposes connection
 // metadata and allows new values to be easily written to it. It's used in
 // authentication handlers and callbacks, and its underlying context.Context is
-// exposed on Session in the session Handler. This also embeds a sync.Locker so
-// values can safely be set between different sessions.
+// exposed on Session in the session Handler. A connection-scoped lock is also
+// embedded in the context to make it easier to limit operations per-connection.
 type Context interface {
 	context.Context
 	sync.Locker

--- a/server.go
+++ b/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	PtyCallback                 PtyCallback                 // callback for allowing PTY sessions, allows all if nil
 	ConnCallback                ConnCallback                // optional callback for wrapping net.Conn before handling
 	LocalPortForwardingCallback LocalPortForwardingCallback // callback for allowing local port forwarding, denies all if nil
+	SessionPolicyCallback       SessionPolicyCallback
 
 	IdleTimeout time.Duration // connection timeout when no activity, none if empty
 	MaxTimeout  time.Duration // absolute connection timeout, none if empty

--- a/ssh.go
+++ b/ssh.go
@@ -42,6 +42,9 @@ type PasswordHandler func(ctx Context, password string) bool
 // PtyCallback is a hook for allowing PTY sessions.
 type PtyCallback func(ctx Context, pty Pty) bool
 
+// SessionPolicyCallback is a callback for allowing SSH sessions.
+type SessionPolicyCallback func(sess Session, requestType string) bool
+
 // ConnCallback is a hook for new connections before handling.
 // It allows wrapping for timeouts and limiting by returning
 // the net.Conn that will be used as the underlying connection.


### PR DESCRIPTION
This is an initial implementation which could probably use a little more testing. Additionally, any feedback on names and interfaces would be welcome.

Note that I added the lock on the context because it's the only way to guarantee that you can add a value to the context without races, but I'd be open to other options.

Closes #7.

This is also meant as a precursor for #79 since I think the default should not allow a subsystem request to go through.