### PR TITLE
Added Server.KeyboardInteractiveHandler

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -2,7 +2,7 @@ package ssh
 
 import (
 	"crypto/subtle"
-	"golang.org/x/crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"net"
 )
 
@@ -41,7 +41,7 @@ type PublicKeyHandler func(ctx Context, key PublicKey) bool
 type PasswordHandler func(ctx Context, password string) bool
 
 // KeyboardInteractiveHandler is a callback for performing keyboard-interactive authentication.
-type KeyboardInteractiveHandler func(ctx Context, challenger ssh.KeyboardInteractiveChallenge) bool
+type KeyboardInteractiveHandler func(ctx Context, challenger gossh.KeyboardInteractiveChallenge) bool
 
 // PtyCallback is a hook for allowing PTY sessions.
 type PtyCallback func(ctx Context, pty Pty) bool

--- a/ssh.go
+++ b/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"crypto/subtle"
+	"golang.org/x/crypto/ssh"
 	"net"
 )
 
@@ -38,6 +39,9 @@ type PublicKeyHandler func(ctx Context, key PublicKey) bool
 
 // PasswordHandler is a callback for performing password authentication.
 type PasswordHandler func(ctx Context, password string) bool
+
+// KeyboardInteractiveHandler is a callback for performing keyboard-interactive authentication.
+type KeyboardInteractiveHandler func(ctx Context, challenger ssh.KeyboardInteractiveChallenge) bool
 
 // PtyCallback is a hook for allowing PTY sessions.
 type PtyCallback func(ctx Context, pty Pty) bool


### PR DESCRIPTION
I needed this in order to implement functionality similar to https://github.com/FiloSottile/whosthere#how-it-works (i.e. I wanted to print a custom error message for users who failed to present any acceptable public keys), so I added this handler.

I'm submitting it for your consideration because having it upstream means less work for _me_, but understand that it's pretty niche and might not be in the spirit of this project. Feel free to use or not :)