### PR TITLE
Add DefaultServerConfigCallback option for create custom default `ServerConfig`s

### DIFF
--- a/server.go
+++ b/server.go
@@ -30,7 +30,8 @@ type Server struct {
 	PtyCallback                   PtyCallback                   // callback for allowing PTY sessions, allows all if nil
 	ConnCallback                  ConnCallback                  // optional callback for wrapping net.Conn before handling
 	LocalPortForwardingCallback   LocalPortForwardingCallback   // callback for allowing local port forwarding, denies all if nil
-	ReversePortForwardingCallback ReversePortForwardingCallback //callback for allowing reverse port forwarding, denies all if nil
+	ReversePortForwardingCallback ReversePortForwardingCallback // callback for allowing reverse port forwarding, denies all if nil
+	DefaultServerConfigCallback   DefaultServerConfigCallback   // callback for configuring detailed SSH options
 
 	IdleTimeout time.Duration // connection timeout when no activity, none if empty
 	MaxTimeout  time.Duration // absolute connection timeout, none if empty
@@ -77,7 +78,12 @@ func (srv *Server) ensureHandlers() {
 }
 
 func (srv *Server) config(ctx Context) *gossh.ServerConfig {
-	config := &gossh.ServerConfig{}
+	var config *gossh.ServerConfig
+	if srv.DefaultServerConfigCallback == nil {
+		config = &gossh.ServerConfig{}
+	} else {
+		config = srv.DefaultServerConfigCallback(ctx)
+	}
 	for _, signer := range srv.HostSigners {
 		config.AddHostKey(signer)
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -57,6 +57,9 @@ type LocalPortForwardingCallback func(ctx Context, destinationHost string, desti
 // ReversePortForwardingCallback is a hook for allowing reverse port forwarding
 type ReversePortForwardingCallback func(ctx Context, bindHost string, bindPort uint32) bool
 
+// DefaultServerConfigCallback is a hook for creating custom default server configs
+type DefaultServerConfigCallback func(ctx Context) *gossh.ServerConfig
+
 // Window represents the size of a PTY window.
 type Window struct {
 	Width  int


### PR DESCRIPTION
This callback allows a more granular control of the SSH server configuration, such as for the key exchange / cipher / MAC algorithms.

Example usage:

```
server := ssh.Server{
  Addr: ":2222",
  // ...
  DefaultServerConfigCallback: func (ctx ssh.Context) *gossh.ServerConfig {
    config := &gossh.ServerConfig{}

    config.KeyExchanges = []string{"curve25519-sha256@libssh.org"}
    config.MACs = []string{"hmac-sha2-256-etm@openssh.com"}
    config.Ciphers = []string{
      "aes128-gcm@openssh.com",
      "ssh-ed25519",
      "ssh-rsa",
    }

    return config
  },
}

server.ListenAndServe()
```