### PR TITLE
wait for child process after client disconnect

### DIFF
--- a/_examples/ssh-pty/pty.go
+++ b/_examples/ssh-pty/pty.go
@@ -37,6 +37,7 @@ func main() {
 				io.Copy(f, s) // stdin
 			}()
 			io.Copy(s, f) // stdout
+			cmd.Wait()
 		} else {
 			io.WriteString(s, "No PTY requested.\n")
 			s.Exit(1)


### PR DESCRIPTION
Without Wait() the child process stays as a zombie process until the server process terminates.