### PR TITLE
Configurable handlers

### DIFF
--- a/server.go
+++ b/server.go
@@ -293,17 +293,13 @@ func (srv *Server) handleRequests(ctx Context, in <-chan *gossh.Request) {
 			handler = srv.RequestHandlers["default"]
 		}
 		if handler == nil {
-			if req.WantReply {
-				req.Reply(false, nil)
-			}
+			req.Reply(false, nil)
 			continue
 		}
 		/*reqCtx, cancel := context.WithCancel(ctx)
 		defer cancel() */
 		ret, payload := handler.HandleSSHRequest(ctx, srv, req)
-		if req.WantReply {
-			req.Reply(ret, payload)
-		}
+		req.Reply(ret, payload)
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -77,7 +77,7 @@ type Session interface {
 // when there is no signal channel specified
 const maxSigBufSize = 128
 
-func sessionHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx Context) {
+func DefaultSessionHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx Context) {
 	ch, reqs, err := newChan.Accept()
 	if err != nil {
 		// TODO: trigger event callback

--- a/session_test.go
+++ b/session_test.go
@@ -19,7 +19,7 @@ func (srv *Server) serveOnce(l net.Listener) error {
 	if e != nil {
 		return e
 	}
-	srv.channelHandlers = map[string]ChannelHandler{
+	srv.ChannelHandlers = map[string]ChannelHandler{
 		"session":      ChannelHandlerFunc(sessionHandler),
 		"direct-tcpip": ChannelHandlerFunc(directTcpipHandler),
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -20,8 +20,8 @@ func (srv *Server) serveOnce(l net.Listener) error {
 		return e
 	}
 	srv.ChannelHandlers = map[string]ChannelHandler{
-		"session":      ChannelHandlerFunc(sessionHandler),
-		"direct-tcpip": ChannelHandlerFunc(directTcpipHandler),
+		"session":      ChannelHandlerFunc(DefaultSessionHandler),
+		"direct-tcpip": ChannelHandlerFunc(DirectTCPIPHandler),
 	}
 	srv.handleConn(conn)
 	return nil

--- a/session_test.go
+++ b/session_test.go
@@ -20,8 +20,8 @@ func (srv *Server) serveOnce(l net.Listener) error {
 		return e
 	}
 	srv.channelHandlers = map[string]ChannelHandler{
-		"session":      sessionHandler,
-		"direct-tcpip": directTcpipHandler,
+		"session":      ChannelHandlerFunc(sessionHandler),
+		"direct-tcpip": ChannelHandlerFunc(directTcpipHandler),
 	}
 	srv.handleConn(conn)
 	return nil

--- a/tcpip.go
+++ b/tcpip.go
@@ -89,7 +89,7 @@ type forwardedTCPHandler struct {
 	sync.Mutex
 }
 
-func (h forwardedTCPHandler) HandleRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
+func (h forwardedTCPHandler) HandleSSHRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
 	h.Lock()
 	if h.forwards == nil {
 		h.forwards = make(map[string]net.Listener)

--- a/tcpip.go
+++ b/tcpip.go
@@ -23,7 +23,9 @@ type localForwardChannelData struct {
 	OriginPort uint32
 }
 
-func directTcpipHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx Context) {
+// DirectTCPIPHandler can be enabled by adding it to the server's
+// ChannelHandlers under direct-tcpip.
+func DirectTCPIPHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx Context) {
 	d := localForwardChannelData{}
 	if err := gossh.Unmarshal(newChan.ExtraData(), &d); err != nil {
 		newChan.Reject(gossh.ConnectionFailed, "error parsing forward data: "+err.Error())
@@ -84,12 +86,15 @@ type remoteForwardChannelData struct {
 	OriginPort uint32
 }
 
-type forwardedTCPHandler struct {
+// ForwardedTCPHandler can be enabled by creating a ForwardedTCPHandler and
+// adding it to the server's RequestHandlers under tcpip-forward and
+// cancel-tcpip-forward.
+type ForwardedTCPHandler struct {
 	forwards map[string]net.Listener
 	sync.Mutex
 }
 
-func (h forwardedTCPHandler) HandleSSHRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
+func (h ForwardedTCPHandler) HandleSSHRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
 	h.Lock()
 	if h.forwards == nil {
 		h.forwards = make(map[string]net.Listener)


### PR DESCRIPTION
This cleans up the configurable-handlers branch, brings some of our handler code more in line with what the stdlib does, and disables port forwarding by default with an option to enable it (we *really* shouldn't have shipped it like this by default).

This does break backwards compatibility (handler changes specifically) but adds quite a bit of flexibility without sacrificing complexity for people who just want to use this package out of the box.

This directly replaces #89 