### PR TITLE
Fix forwardedTCPHandler

### DIFF
--- a/server.go
+++ b/server.go
@@ -69,8 +69,8 @@ func (srv *Server) ensureHandlers() {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	srv.requestHandlers = map[string]RequestHandler{
-		"tcpip-forward":        forwardedTCPHandler{},
-		"cancel-tcpip-forward": forwardedTCPHandler{},
+		"tcpip-forward":        &forwardedTCPHandler{},
+		"cancel-tcpip-forward": &forwardedTCPHandler{},
 	}
 	srv.channelHandlers = map[string]channelHandler{
 		"session":      sessionHandler,

--- a/server.go
+++ b/server.go
@@ -68,9 +68,10 @@ func (srv *Server) ensureHostSigner() error {
 func (srv *Server) ensureHandlers() {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	forwardTCPHandler := &forwardedTCPHandler{}
 	srv.requestHandlers = map[string]RequestHandler{
-		"tcpip-forward":        &forwardedTCPHandler{},
-		"cancel-tcpip-forward": &forwardedTCPHandler{},
+		"tcpip-forward":        forwardTCPHandler,
+		"cancel-tcpip-forward": forwardTCPHandler,
 	}
 	srv.channelHandlers = map[string]channelHandler{
 		"session":      sessionHandler,

--- a/tcpip.go
+++ b/tcpip.go
@@ -89,7 +89,7 @@ type forwardedTCPHandler struct {
 	sync.Mutex
 }
 
-func (h forwardedTCPHandler) HandleRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
+func (h *forwardedTCPHandler) HandleRequest(ctx Context, srv *Server, req *gossh.Request) (bool, []byte) {
 	h.Lock()
 	if h.forwards == nil {
 		h.forwards = make(map[string]net.Listener)


### PR DESCRIPTION
This fixes an issue when a forwarding client disconnects from the server, the listening port remains open because `forwards map[string]net.Listener` are never changed due a mutability issue in `forwardedTCPHandler`