### PR TITLE
Add Session.RawCommand()

### DIFF
--- a/session.go
+++ b/session.go
@@ -44,6 +44,9 @@ type Session interface {
 	// which considers quoting not just whitespace.
 	Command() []string
 
+	// RawCommand returns the exact command that was provided by the user.
+	RawCommand() string
+
 	// PublicKey returns the PublicKey used to authenticate. If a public key was not
 	// used it will return nil.
 	PublicKey() PublicKey
@@ -106,7 +109,7 @@ type session struct {
 	env       []string
 	ptyCb     PtyCallback
 	sessReqCb SessionRequestCallback
-	cmd       []string
+	rawCmd    string
 	ctx       Context
 	sigCh     chan<- Signal
 	sigBuf    []Signal
@@ -179,8 +182,13 @@ func (sess *session) Environ() []string {
 	return append([]string(nil), sess.env...)
 }
 
+func (sess *session) RawCommand() string {
+	return sess.rawCmd
+}
+
 func (sess *session) Command() []string {
-	return append([]string(nil), sess.cmd...)
+	cmd, _ := shlex.Split(sess.rawCmd, true)
+	return append([]string(nil), cmd...)
 }
 
 func (sess *session) Pty() (Pty, <-chan Window, bool) {
@@ -214,12 +222,12 @@ func (sess *session) handleRequests(reqs <-chan *gossh.Request) {
 
 			var payload = struct{ Value string }{}
 			gossh.Unmarshal(req.Payload, &payload)
-			sess.cmd, _ = shlex.Split(payload.Value, true)
+			sess.rawCmd = payload.Value
 
 			// If there's a session policy callback, we need to confirm before
 			// accepting the session.
 			if sess.sessReqCb != nil && !sess.sessReqCb(sess, req.Type) {
-				sess.cmd = nil
+				sess.rawCmd = ""
 				req.Reply(false, nil)
 				continue
 			}


### PR DESCRIPTION
My main use case for this would be SSH_ORIGINAL_COMMAND. Many SSH servers set this when running commands on the server itself, and it's very annoying (and error prone) to set without having the RawCommand. I also opted for only calling shlex when needed, as it's an operation which doesn't need to be done in all cases.

This would replace #93 (Proper attribution for @andrewchambers is still there) as the original pull request is missing the line to actually set rawCmd.