### PR TITLE
Add subsystem support

### DIFF
--- a/session.go
+++ b/session.go
@@ -47,6 +47,9 @@ type Session interface {
 	// RawCommand returns the exact command that was provided by the user.
 	RawCommand() string
 
+	// Subsystem returns the subsystem requested by the user.
+	Subsystem() string
+
 	// PublicKey returns the PublicKey used to authenticate. If a public key was not
 	// used it will return nil.
 	PublicKey() PublicKey
@@ -87,12 +90,13 @@ func DefaultSessionHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.Ne
 		return
 	}
 	sess := &session{
-		Channel:   ch,
-		conn:      conn,
-		handler:   srv.Handler,
-		ptyCb:     srv.PtyCallback,
-		sessReqCb: srv.SessionRequestCallback,
-		ctx:       ctx,
+		Channel:           ch,
+		conn:              conn,
+		handler:           srv.Handler,
+		ptyCb:             srv.PtyCallback,
+		sessReqCb:         srv.SessionRequestCallback,
+		subsystemHandlers: srv.SubsystemHandlers,
+		ctx:               ctx,
 	}
 	sess.handleRequests(reqs)
 }
@@ -100,19 +104,21 @@ func DefaultSessionHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.Ne
 type session struct {
 	sync.Mutex
 	gossh.Channel
-	conn      *gossh.ServerConn
-	handler   Handler
-	handled   bool
-	exited    bool
-	pty       *Pty
-	winch     chan Window
-	env       []string
-	ptyCb     PtyCallback
-	sessReqCb SessionRequestCallback
-	rawCmd    string
-	ctx       Context
-	sigCh     chan<- Signal
-	sigBuf    []Signal
+	conn              *gossh.ServerConn
+	handler           Handler
+	subsystemHandlers map[string]SubsystemHandler
+	handled           bool
+	exited            bool
+	pty               *Pty
+	winch             chan Window
+	env               []string
+	ptyCb             PtyCallback
+	sessReqCb         SessionRequestCallback
+	rawCmd            string
+	subsystem         string
+	ctx               Context
+	sigCh             chan<- Signal
+	sigBuf            []Signal
 }
 
 func (sess *session) Write(p []byte) (n int, err error) {
@@ -191,6 +197,10 @@ func (sess *session) Command() []string {
 	return append([]string(nil), cmd...)
 }
 
+func (sess *session) Subsystem() string {
+	return sess.subsystem
+}
+
 func (sess *session) Pty() (Pty, <-chan Window, bool) {
 	if sess.pty != nil {
 		return *sess.pty, sess.winch, true
@@ -237,6 +247,40 @@ func (sess *session) handleRequests(reqs <-chan *gossh.Request) {
 
 			go func() {
 				sess.handler(sess)
+				sess.Exit(0)
+			}()
+		case "subsystem":
+			if sess.handled {
+				req.Reply(false, nil)
+				continue
+			}
+
+			var payload = struct{ Value string }{}
+			gossh.Unmarshal(req.Payload, &payload)
+			sess.subsystem = payload.Value
+
+			// If there's a session policy callback, we need to confirm before
+			// accepting the session.
+			if sess.sessReqCb != nil && !sess.sessReqCb(sess, req.Type) {
+				sess.rawCmd = ""
+				req.Reply(false, nil)
+				continue
+			}
+
+			handler := sess.subsystemHandlers[payload.Value]
+			if handler == nil {
+				handler = sess.subsystemHandlers["default"]
+			}
+			if handler == nil {
+				req.Reply(false, nil)
+				continue
+			}
+
+			sess.handled = true
+			req.Reply(true, nil)
+
+			go func() {
+				handler(sess)
 				sess.Exit(0)
 			}()
 		case "env":


### PR DESCRIPTION
This subsystem support is based on the new handler work, but allows for flexible subsystem handlers at the server level.