### PR TITLE
Make Context implement "x/crypto/ssh".ConnMetadata interface

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"context"
-	"encoding/hex"
 	"net"
 	"sync"
 
@@ -70,13 +69,13 @@ type Context interface {
 	User() string
 
 	// SessionID returns the session hash.
-	SessionID() string
+	SessionID() []byte
 
 	// ClientVersion returns the version reported by the client.
-	ClientVersion() string
+	ClientVersion() []byte
 
 	// ServerVersion returns the version reported by the server.
-	ServerVersion() string
+	ServerVersion() []byte
 
 	// RemoteAddr returns the remote address for this connection.
 	RemoteAddr() net.Addr
@@ -111,9 +110,9 @@ func applyConnMetadata(ctx Context, conn gossh.ConnMetadata) {
 	if ctx.Value(ContextKeySessionID) != nil {
 		return
 	}
-	ctx.SetValue(ContextKeySessionID, hex.EncodeToString(conn.SessionID()))
-	ctx.SetValue(ContextKeyClientVersion, string(conn.ClientVersion()))
-	ctx.SetValue(ContextKeyServerVersion, string(conn.ServerVersion()))
+	ctx.SetValue(ContextKeySessionID, conn.SessionID())
+	ctx.SetValue(ContextKeyClientVersion, conn.ClientVersion())
+	ctx.SetValue(ContextKeyServerVersion, conn.ServerVersion())
 	ctx.SetValue(ContextKeyUser, conn.User())
 	ctx.SetValue(ContextKeyLocalAddr, conn.LocalAddr())
 	ctx.SetValue(ContextKeyRemoteAddr, conn.RemoteAddr())
@@ -127,16 +126,16 @@ func (ctx *sshContext) User() string {
 	return ctx.Value(ContextKeyUser).(string)
 }
 
-func (ctx *sshContext) SessionID() string {
-	return ctx.Value(ContextKeySessionID).(string)
+func (ctx *sshContext) SessionID() []byte {
+	return ctx.Value(ContextKeySessionID).([]byte)
 }
 
-func (ctx *sshContext) ClientVersion() string {
-	return ctx.Value(ContextKeyClientVersion).(string)
+func (ctx *sshContext) ClientVersion() []byte {
+	return ctx.Value(ContextKeyClientVersion).([]byte)
 }
 
-func (ctx *sshContext) ServerVersion() string {
-	return ctx.Value(ContextKeyServerVersion).(string)
+func (ctx *sshContext) ServerVersion() []byte {
+	return ctx.Value(ContextKeyServerVersion).([]byte)
 }
 
 func (ctx *sshContext) RemoteAddr() net.Addr {

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,10 @@
 package ssh
 
-import "testing"
+import (
+	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
+)
 
 func TestSetPermissions(t *testing.T) {
 	t.Parallel()
@@ -43,5 +47,12 @@ func TestSetValue(t *testing.T) {
 	defer cleanup()
 	if err := session.Run(""); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestContextAsConnMetadata (t *testing.T) {
+	var s Context = &sshContext{}
+	if _, ok := s.(gossh.ConnMetadata); !ok {
+		t.Error("Context unusable as ConnMetadata")
 	}
 }


### PR DESCRIPTION
This package's `Context` interface is _almost_, but not quite, identical to x/crypto/ssh's `ConnMetadata` interface. Seeing how similar they are, I wonder if the differences are unintentional.

I'm pretty sure anyone implementing certificate-based user authentication will run into this interface mismatch while trying to plumb connection details through to a `CertChecker`, because code like the simple example below fails to typecheck:

```go
    // gossh refers to x/crypto/ssh
    // ssh refers to gliderlabs/ssh

    checker := gossh.CertChecker{
        IsUserAuthority: func(pub gossh.PublicKey) bool {
            // our own logic to check whether pub is acceptable
            return true
        }
    }

    func isUserCertOK(ctx ssh.Context, key ssh.PublicKey) bool {
        if cert, ok := key.(*gossh.Certificate); ok {
            _, err := checker.Authenticate(ctx, cert)
            return err == nil
        }
        // return isNonCertificateSshKeyOK(ctx, key)
    }

    sshServer := &ssh.Server{
        // ...
        PublicKeyHandler: isUserCertOK,
    }
```

This PR slightly changes the `Context` interface so that an `sshContext` conforms to `ConnMetadata`. Specifically:
- Make `ClientVersion()`, `ServerVersion()`, and `SessionID()` return `[]byte` instead of `string`
- Add a type assertion to `context_test.go`

This is a breaking change, so I'll leave it to the maintainers to decide if and when to merge.

Thanks for this great library!