### PR TITLE
fix "Setctty set but Ctty not valid in child"  problem in pty example

### DIFF
--- a/_examples/ssh-pty/pty.go
+++ b/_examples/ssh-pty/pty.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/gliderlabs/ssh"
-	"github.com/kr/pty"
+	"github.com/creack/pty"
 )
 
 func setWinsize(f *os.File, w, h int) {


### PR DESCRIPTION
problem occurred in go1.15 and upstream  https://github.com/creack/pty/issues/96