### PR TITLE
Register chan to Session to listen for break requests

### DIFF
--- a/session.go
+++ b/session.go
@@ -359,11 +359,13 @@ func (sess *session) handleRequests(reqs <-chan *gossh.Request) {
 			req.Reply(true, nil)
 		case "break":
 			ok := false
+			sess.Lock()
 			if sess.breakCh != nil {
 				sess.breakCh <- true
 				ok = true
 			}
 			req.Reply(ok, nil)
+			sess.Unlock()
 		default:
 			// TODO: debug log
 			req.Reply(false, nil)


### PR DESCRIPTION
This change supports break over SSH (https://tools.ietf.org/html/rfc4335) by adding a method to Session to register a channel to indicate that a break request was received.