### PR TITLE
Add ConnectionFailedCallback to enable reporting of failed connection

### DIFF
--- a/server.go
+++ b/server.go
@@ -48,6 +48,8 @@ type Server struct {
 	ServerConfigCallback          ServerConfigCallback          // callback for configuring detailed SSH options
 	SessionRequestCallback        SessionRequestCallback        // callback for allowing or denying SSH sessions
 
+	ConnectionFailedCallback ConnectionFailedCallback // callback to report connection failures
+
 	IdleTimeout time.Duration // connection timeout when no activity, none if empty
 	MaxTimeout  time.Duration // absolute connection timeout, none if empty
 
@@ -278,7 +280,9 @@ func (srv *Server) HandleConn(newConn net.Conn) {
 	defer conn.Close()
 	sshConn, chans, reqs, err := gossh.NewServerConn(conn, srv.config(ctx))
 	if err != nil {
-		// TODO: trigger event callback
+		if srv.ConnectionFailedCallback != nil {
+			srv.ConnectionFailedCallback(conn, err)
+		}
 		return
 	}
 

--- a/ssh.go
+++ b/ssh.go
@@ -64,6 +64,10 @@ type ReversePortForwardingCallback func(ctx Context, bindHost string, bindPort u
 // ServerConfigCallback is a hook for creating custom default server configs
 type ServerConfigCallback func(ctx Context) *gossh.ServerConfig
 
+// ConnectionFailedCallback is a hook for reporting failed connections
+// Please note: the net.Conn is likely to be closed at this point
+type ConnectionFailedCallback func(conn net.Conn, err error)
+
 // Window represents the size of a PTY window.
 type Window struct {
 	Width  int


### PR DESCRIPTION
This PR adds a new callback function to allow for the final error during attempted authentication to be logged by the containing program.

Without this it's impossible to handle or add add fail2ban configuration to software using gliderlabs ssh.

Signed-off-by: Andrew Thornton <art27@cantab.net>