### PR TITLE
Prevent Context.RemoteAddr() from exploding when called from ConnCallback

### DIFF
--- a/context.go
+++ b/context.go
@@ -140,7 +140,10 @@ func (ctx *sshContext) ServerVersion() string {
 }
 
 func (ctx *sshContext) RemoteAddr() net.Addr {
-	return ctx.Value(ContextKeyRemoteAddr).(net.Addr)
+	if addr, ok := ctx.Value(ContextKeyRemoteAddr).(net.Addr); ok {
+		return addr
+	}
+	return nil
 }
 
 func (ctx *sshContext) LocalAddr() net.Addr {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/gliderlabs/ssh
+
+go 1.16
+
+require (
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
When calling ctx.RemoteAddr() within ConnCallback one gets a panic due to
unsafe casting within the accessor. I understand it's not a valid scenario
as such, but I accidentally called a logger that expected that checked
for RemoteAddr() in ssh.Context

panic: interface conversion: interface is nil, not net.Addr

Signed-off-by: Alejandro Mery <amery@geeks.cl>