### PR TITLE
add PasswordAuthE func, which is like PasswordAuth but returns error instead of bool

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package ssh_test
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -17,6 +18,17 @@ func ExamplePasswordAuth() {
 	ssh.ListenAndServe(":2222", nil,
 		ssh.PasswordAuth(func(ctx ssh.Context, pass string) bool {
 			return pass == "secret"
+		}),
+	)
+}
+
+func ExamplePasswordAuthE() {
+	ssh.ListenAndServe(":2222", nil,
+		ssh.PasswordAuthE(func(ctx ssh.Context, pass string) error {
+			if pass == "secret" {
+				return nil
+			}
+			return fmt.Errorf("password incorrect")
 		}),
 	)
 }

--- a/options.go
+++ b/options.go
@@ -14,6 +14,14 @@ func PasswordAuth(fn PasswordHandler) Option {
 	}
 }
 
+// PasswordAuthE returns a functional option that sets PasswordHandlerE on the server.
+func PasswordAuthE(fn PasswordHandlerE) Option {
+	return func(srv *Server) error {
+		srv.PasswordHandlerE = fn
+		return nil
+	}
+}
+
 // PublicKeyAuth returns a functional option that sets PublicKeyHandler on the server.
 func PublicKeyAuth(fn PublicKeyHandler) Option {
 	return func(srv *Server) error {

--- a/server.go
+++ b/server.go
@@ -40,6 +40,7 @@ type Server struct {
 
 	KeyboardInteractiveHandler    KeyboardInteractiveHandler    // keyboard-interactive authentication handler
 	PasswordHandler               PasswordHandler               // password authentication handler
+	PasswordHandlerE              PasswordHandlerE              // password authentiication handler with error, if it is set, it overrides PasswordHandler
 	PublicKeyHandler              PublicKeyHandler              // public key authentication handler
 	PtyCallback                   PtyCallback                   // callback for allowing PTY sessions, allows all if nil
 	ConnCallback                  ConnCallback                  // optional callback for wrapping net.Conn before handling
@@ -126,7 +127,7 @@ func (srv *Server) config(ctx Context) *gossh.ServerConfig {
 	for _, signer := range srv.HostSigners {
 		config.AddHostKey(signer)
 	}
-	if srv.PasswordHandler == nil && srv.PublicKeyHandler == nil && srv.KeyboardInteractiveHandler == nil {
+	if srv.PasswordHandler == nil && srv.PasswordHandlerE == nil && srv.PublicKeyHandler == nil && srv.KeyboardInteractiveHandler == nil {
 		config.NoClientAuth = true
 	}
 	if srv.Version != "" {
@@ -139,6 +140,13 @@ func (srv *Server) config(ctx Context) *gossh.ServerConfig {
 				return ctx.Permissions().Permissions, fmt.Errorf("permission denied")
 			}
 			return ctx.Permissions().Permissions, nil
+		}
+	}
+	if srv.PasswordHandlerE != nil {
+		config.PasswordCallback = func(conn gossh.ConnMetadata, password []byte) (*gossh.Permissions, error) {
+			applyConnMetadata(ctx, conn)
+			err := srv.PasswordHandlerE(ctx, string(password))
+			return ctx.Permissions().Permissions, err
 		}
 	}
 	if srv.PublicKeyHandler != nil {

--- a/ssh.go
+++ b/ssh.go
@@ -41,6 +41,9 @@ type PublicKeyHandler func(ctx Context, key PublicKey) bool
 // PasswordHandler is a callback for performing password authentication.
 type PasswordHandler func(ctx Context, password string) bool
 
+// PasswordHandlerE is like PasswordHandler, but returns error
+type PasswordHandlerE func(ctx Context, password string) error
+
 // KeyboardInteractiveHandler is a callback for performing keyboard-interactive authentication.
 type KeyboardInteractiveHandler func(ctx Context, challenger gossh.KeyboardInteractiveChallenge) bool
 


### PR DESCRIPTION
Add `PasswordAuthE` function, because sometimes ssh server should returns detailed error than "permission denied".
if `PasswordAuthE`and `PasswordAuth` both set, `PasswordAuthE` will overwrite PasswordAuth