### PR TITLE
Make sshContext thread safe and fix the data race bug

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,9 @@
 package ssh
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestSetPermissions(t *testing.T) {
 	t.Parallel()
@@ -43,5 +46,40 @@ func TestSetValue(t *testing.T) {
 	defer cleanup()
 	if err := session.Run(""); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSetValueConcurrency(t *testing.T) {
+	ctx, cancel := newContext(nil)
+	defer cancel()
+
+	go func() {
+		for { // use a loop to access context.Context functions to make sure they are thread-safe with SetValue
+			_, _ = ctx.Deadline()
+			_ = ctx.Err()
+			_ = ctx.Value("foo")
+			select {
+			case <-ctx.Done():
+				break
+			default:
+			}
+		}
+	}()
+	ctx.SetValue("bar", -1) // a context value which never changes
+	now := time.Now()
+	var cnt int64
+	go func() {
+		for time.Since(now) < 100*time.Millisecond {
+			cnt++
+			ctx.SetValue("foo", cnt) // a context value which changes a lot
+		}
+		cancel()
+	}()
+	<-ctx.Done()
+	if ctx.Value("foo") != cnt {
+		t.Fatal("context.Value(foo) doesn't match latest SetValue")
+	}
+	if ctx.Value("bar") != -1 {
+		t.Fatal("context.Value(bar) doesn't match latest SetValue")
 	}
 }


### PR DESCRIPTION
Fix #160

The problem in old code, suppose there are 2 goroutines:

1. Goroutine-A calls the `context.Context` interface functions of `sshCtx`, then it reads `sshCtx.Context`
2. Goroutine-B calls `sshCtx.SetValue`, then it writes `sshCtx.Context`
3. Then, data race occurs

This PR makes the `sshCtx.Context` immutable, there won't be data race issue.

The `Mutex.Lock/Unlock` is quite fast when there is no concurrency, it only calls `atomic.CompareAndSwapInt32` / `atomic.AddInt32`. 
