### PR TITLE
fix: remove ioutil deprecations

### DIFF
--- a/_examples/ssh-sftpserver/sftp.go
+++ b/_examples/ssh-sftpserver/sftp.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 
 	"github.com/gliderlabs/ssh"
@@ -12,7 +11,7 @@ import (
 
 // SftpHandler handler for SFTP subsystem
 func SftpHandler(sess ssh.Session) {
-	debugStream := ioutil.Discard
+	debugStream := io.Discard
 	serverOptions := []sftp.ServerOption{
 		sftp.WithDebug(debugStream),
 	}

--- a/agent.go
+++ b/agent.go
@@ -2,8 +2,8 @@ package ssh
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"sync"
 
@@ -36,7 +36,7 @@ func AgentRequested(sess Session) bool {
 // NewAgentListener sets up a temporary Unix socket that can be communicated
 // to the session environment and used for forwarding connections.
 func NewAgentListener() (net.Listener, error) {
-	dir, err := ioutil.TempDir("", agentTempDir)
+	dir, err := os.MkdirTemp("", agentTempDir)
 	if err != nil {
 		return nil, err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -2,7 +2,7 @@ package ssh_test
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/gliderlabs/ssh"
 )
@@ -28,7 +28,7 @@ func ExampleNoPty() {
 func ExamplePublicKeyAuth() {
 	ssh.ListenAndServe(":2222", nil,
 		ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
-			data, _ := ioutil.ReadFile("/path/to/allowed/key.pub")
+			data, _ := os.ReadFile("/path/to/allowed/key.pub")
 			allowed, _, _, _, _ := ssh.ParseAuthorizedKey(data)
 			return ssh.KeysEqual(key, allowed)
 		}),

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package ssh
 
 import (
-	"io/ioutil"
+	"os"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -26,7 +26,7 @@ func PublicKeyAuth(fn PublicKeyHandler) Option {
 // from a PEM file at filepath.
 func HostKeyFile(filepath string) Option {
 	return func(srv *Server) error {
-		pemBytes, err := ioutil.ReadFile(filepath)
+		pemBytes, err := os.ReadFile(filepath)
 		if err != nil {
 			return err
 		}

--- a/tcpip_test.go
+++ b/tcpip_test.go
@@ -2,7 +2,7 @@ package ssh
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -58,7 +58,7 @@ func TestLocalPortForwardingWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error connecting to %v: %v", l.Addr().String(), err)
 	}
-	result, err := ioutil.ReadAll(conn)
+	result, err := io.ReadAll(conn)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`ioutil` was deprecated as of Go 1.16