### PR TITLE
_examples/ssh-sftpserver: close server if it exited without error

### DIFF
--- a/_examples/ssh-sftpserver/sftp.go
+++ b/_examples/ssh-sftpserver/sftp.go
@@ -23,10 +23,10 @@ func SftpHandler(sess ssh.Session) {
 		log.Printf("sftp server init error: %s\n", err)
 		return
 	}
-	if err := server.Serve(); err == io.EOF {
+	if err := server.Serve(); err == io.EOF || err == nil {
 		server.Close()
 		fmt.Println("sftp client exited session.")
-	} else if err != nil {
+	} else {
 		fmt.Println("sftp server completed with error:", err)
 	}
 }


### PR DESCRIPTION
On my system, the message wasn't being printed when `sftp` connection exited (I types `exit` in sftp). Let me know if I misunderstood something.