### PR TITLE
Fix ineffective break statement in context_test.go

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -60,7 +60,7 @@ func TestSetValueConcurrency(t *testing.T) {
 			_ = ctx.Value("foo")
 			select {
 			case <-ctx.Done():
-				break
+				return
 			default:
 			}
 		}


### PR DESCRIPTION
From https://staticcheck.dev/docs/checks#SA4011:

SA4011 - Break statement with no effect. Did you mean to break out of an outer loop?

In Go, the break statement only exits the innermost loop it's currently in. If you're seeing the "ineffective break statement" warning, it's likely because you have a break statement inside a nested loop, but you intended to exit the outer loop.

Updating with a `return` to exit the goroutine entirely.  The unit test itself isn't affected;  it passes before and after this change.